### PR TITLE
feat: simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ ARG HOME
 WORKDIR ${HOME}
 RUN apt-get update && \
   apt-get install -y curl git gcc make && rm -rf /var/lib/apt/lists/* && \
-  curl https://raw.githubusercontent.com/emizzle/nimv/refs/heads/master/nimv.sh | bash -s "${NIM_VERSION}" && \
-  rm -rf "${HOME}/.nimv/${NIM_VERSION}/Nim/.git" && \
-  rm -rf "${HOME}/.nimv/${NIM_VERSION}/Nim/dist" && \
-  rm -rf "${HOME}/.nimv/${NIM_VERSION}/Nim/tests" && \
-  rm -rf "${HOME}/.nimv/${NIM_VERSION}/Nim/nimcache" && \
-  rm -rf "${HOME}/.nimv/${NIM_VERSION}/Nim/csources_v2"
+  curl https://raw.githubusercontent.com/emizzle/nimv/refs/heads/master/nimv.sh | bash -s "${NIM_VERSION}"
 
 ENV PATH=${HOME}/.nimble/bin:${PATH}


### PR DESCRIPTION
Based on the [`nimv 0.0.4`](https://github.com/emizzle/nimv/releases/tag/0.0.4) changes, we can simplify Dockerfile
> - Clean up Nim installation sources after Nim install

A simple test shows the following
```shell
# Old
e3c1ac5d6237 - linux/amd64    - 193.6 MB
4efa79b416e9 - linux/arm64    - 187.34 MB

# Updated
57d2253be6b3 - linux/amd64    - 179.31 MB
e3b068204ff4 - linux/arm64/v8 - 173.61 MB
```